### PR TITLE
Add lookup support to autocreatelist

### DIFF
--- a/SPReplicator/functions/Add-SPRColumn.ps1
+++ b/SPReplicator/functions/Add-SPRColumn.ps1
@@ -1,5 +1,5 @@
 ﻿Function Add-SPRColumn {
-<#
+    <#
 .SYNOPSIS
     Adds a column to a SharePoint list.
 
@@ -157,7 +157,7 @@
                     $ColumnName = $xmldata.Field.Name
                 }
                 if ((Test-PSFShouldProcess -PSCmdlet $PSCmdlet -Target $server.Url -Action "Added $ColumnName as $Type to $List")) {
-                    Write-PSFMessage -Level Debug -Message $xml
+                    Write-PSFMessage -Level Verbose -Message $xml
                     $null = $thislist.Fields.AddFieldAsXml($xml, $addtodefaultlist, $FieldOption)
                     $thislist.Update()
                     $server.Load($thislist)

--- a/SPReplicator/functions/Add-SPRListItem.ps1
+++ b/SPReplicator/functions/Add-SPRListItem.ps1
@@ -197,7 +197,7 @@
                     }
                 }
                 
-                if ($type -notin $validcolumntypes -or (-not $AllowUserField -and $type -eq 'User')) {
+                if ($type -notin $validcolumntypes -or (-not $AllowUserField -and $type -eq "User") -or $type -eq "Lookup") {
                     $type = "Note"
                 }
                 

--- a/SPReplicator/functions/Export-SPRListItem.ps1
+++ b/SPReplicator/functions/Export-SPRListItem.ps1
@@ -121,7 +121,7 @@
                 $spdatatype = $tempdatatype
             }
             
-            $columns = $columns | Where-Object ReadOnlyField -eq $false
+            # $columns = $columns | Where-Object ReadOnlyField -eq $false
             $columnsnames = $columns.Name | Select-Object -Unique
             [PSCustomObject]@{
                 SPReplicatorDataType = $spdatatype

--- a/SPReplicator/functions/Export-SPRListItem.ps1
+++ b/SPReplicator/functions/Export-SPRListItem.ps1
@@ -100,7 +100,7 @@
     end {
         try {
             $columns = $collection | Select-Object -First 1 -ExpandProperty ListObject | Get-SPRColumnDetail |
-            Where-Object {
+                Where-Object {
                 ($PSItem.Type -eq 'Lookup' -and $PSItem.FromBaseType -eq $false) -or ($PSItem.Name -in 'UID', 'RecurrenceData', 'XMLTZone', 'RecurrenceID', 'TimeZone', 'Duration', 'EventType' ) -or (-not $psitem.Hidden -and -not $PSItem.ReadOnly -and $PSItem.Type -ne 'Computed' -and $PSItem.Name -notin 'Created', 'Author', 'Editor', '_UIVersionString', 'Modified', 'Attachments')
             }
             $spdatatype = $columns | Select-SPRObject -Property Name, 'TypeAsString as Type'
@@ -121,6 +121,7 @@
                 $spdatatype = $tempdatatype
             }
             
+            $columns = $columns | Where-Object ReadOnlyField -eq $false
             $columnsnames = $columns.Name | Select-Object -Unique
             [PSCustomObject]@{
                 SPReplicatorDataType = $spdatatype

--- a/SPReplicator/functions/Export-SPRListItem.ps1
+++ b/SPReplicator/functions/Export-SPRListItem.ps1
@@ -103,25 +103,26 @@
                 Where-Object {
                 ($PSItem.Type -eq 'Lookup' -and $PSItem.FromBaseType -eq $false) -or ($PSItem.Name -in 'UID', 'RecurrenceData', 'XMLTZone', 'RecurrenceID', 'TimeZone', 'Duration', 'EventType' ) -or (-not $psitem.Hidden -and -not $PSItem.ReadOnly -and $PSItem.Type -ne 'Computed' -and $PSItem.Name -notin 'Created', 'Author', 'Editor', '_UIVersionString', 'Modified', 'Attachments')
             }
-            $spdatatype = $columns | Select-SPRObject -Property Name, 'TypeAsString as Type'
+            $spdatatype = $columns | Select-SPRObject -Property Name, 'TypeAsString as Type', 'ReadOnlyField as ReadOnly'
 
             if (-not $EnableUserField) {
                 $tempdatatype = @()
                 foreach ($dt in $spdatatype) {
                     $name = $dt.Name
                     $type = $dt.Type
+                    $readonly = $dt.ReadOnly
                     if ($type -eq 'User') {
                         $type = 'Text'
                     }
                     $tempdatatype += [pscustomobject]@{
-                        Name = $name
-                        Type = $type
+                        Name     = $name
+                        Type     = $type
+                        ReadOnly = $readonly
                     }
                 }
                 $spdatatype = $tempdatatype
             }
             
-            # $columns = $columns | Where-Object ReadOnlyField -eq $false
             $columnsnames = $columns.Name | Select-Object -Unique
             [PSCustomObject]@{
                 SPReplicatorDataType = $spdatatype

--- a/SPReplicator/functions/Import-SPRListItem.ps1
+++ b/SPReplicator/functions/Import-SPRListItem.ps1
@@ -1,5 +1,5 @@
 ﻿Function Import-SPRListItem {
-<#
+    <#
 .SYNOPSIS
     Imports all items from a file into a SharePoint list.
 
@@ -75,8 +75,8 @@
     Imports all items from C:\temp\mylist.dat to My List on intranet.ad.local. Remaps People Picker entry brice.hagood to bhagood to accommodate for different naming conventions. Otherwise, People Picker will attempt to resolve brice.hagood on the potentially new domain.
 
 #>
-	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingEmptyCatchBlock", "")]
-	[CmdletBinding(SupportsShouldProcess)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingEmptyCatchBlock", "")]
+    [CmdletBinding(SupportsShouldProcess)]
     param (
         [Parameter(Position = 0, Mandatory, HelpMessage = "Human-readble SharePoint list name")]
         [string]$List,
@@ -122,16 +122,21 @@
                 catch {
                     # Don't care because it may or may not exist
                 }
-                if ($file.length/1MB -gt 100) {
+                if ($file.length / 1MB -gt 100) {
                     if ($Column) {
                         $items = Import-PSFClixml -Path $file | Select-Object -ExpandProperty Data | Select-SPRObject -Property $Column | Add-SPRListItem -Site $Site -Credential $Credential -List $List -Web $Web -AutoCreateList:$AutoCreateList -AsUser $AsUser -Quiet:$Quiet -LogToList $LogToList -DataTypeMap $datatypemap -Column $Column -ExcludeColumn $ExcludeColumn -DomainMap $DomainMap -UserMap $UserMap
-                    } elseif ($ExcludeColumn) {
+                    }
+                    elseif ($ExcludeColumn) {
                         $items = Import-PSFClixml -Path $file | Select-Object -ExpandProperty Data | Select-SPRObject -ExcludeProperty $ExcludeColumn | Add-SPRListItem -Site $Site -Credential $Credential -List $List -Web $Web -AutoCreateList:$AutoCreateList -AsUser $AsUser -Quiet:$Quiet -LogToList $LogToList -DataTypeMap $datatypemap -Column $Column -ExcludeColumn $ExcludeColumn -DomainMap $DomainMap -UserMap $UserMap
-                    } else {
+                    }
+                    else {
                         $items = Import-PSFClixml -Path $file | Select-Object -ExpandProperty Data | Add-SPRListItem -Site $Site -Credential $Credential -List $List -Web $Web -AutoCreateList:$AutoCreateList -AsUser $AsUser -Quiet:$Quiet -LogToList $LogToList -DataTypeMap $datatypemap -Column $Column -ExcludeColumn $ExcludeColumn -DomainMap $DomainMap -UserMap $UserMap
                     }
-                } else {
+                }
+                else {
                     $items = Import-PSFClixml -Path $file | Select-Object -ExpandProperty Data
+                    $ExcludeColumn += $datatypemap | Where-Object { $PSItem.Type -eq "Lookup" -and $PSItem.ReadOnly -eq $true } | Select-Object -ExpandProperty Name
+
                     if ($Column) {
                         $items = $items | Select-SPRObject -Property $Column
                     }
@@ -140,7 +145,8 @@
                     }
                     Add-SPRListItem -Site $Site -Credential $Credential -List $List -Web $Web -AutoCreateList:$AutoCreateList -InputObject $items -AsUser $AsUser -Quiet:$Quiet -LogToList $LogToList -DataTypeMap $datatypemap -Column $Column -ExcludeColumn $ExcludeColumn -DomainMap $DomainMap -UserMap $UserMap
                 }
-            } catch {
+            }
+            catch {
                 Stop-PSFFunction -EnableException:$EnableException -Message "Failure" -ErrorRecord $_ -Continue
             }
         }


### PR DESCRIPTION
when autocreating, it'll just smash down lookups to text because we can't be certain that the destination list exists. to support lookups, manually create the list.